### PR TITLE
docs: add min_version 2024.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ SN: XXXX-XXXXX-XX
 
 1. **Install ESPHome:** If you haven't already, install ESPHome by following the instructions [here](https://esphome.io/guides/getting_started_command_line.html#installation-step) or [here in combination with HA](https://esphome.io/guides/getting_started_hassio.html).
 
+   Make sure you install at least the ESPhome version 2024.2.0. The latest version is always recommended.
+
    You then need to create a new YAML configuration for you nexxtender charger, compile it (this will create the corresponding C++ code and resulting binary), and upload it to your esp32.
 
    ```yaml

--- a/config/nexxtender_packages/esp.yaml
+++ b/config/nexxtender_packages/esp.yaml
@@ -11,6 +11,7 @@ esp32:
       CONFIG_BT_GATTC_NOTIF_REG_MAX: "32"
 
 esphome:
+  min_version: 2024.2.0
   name: ${device_name}
   friendly_name: ${friendly_name}
   includes:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated installation and configuration instructions for the ESPHome BLE client for the Powerdale Nexxtender EV Charger.
	- Added new version requirements, emphasizing the need for ESPHome version 2024.2.0 or later.
	- Clarified instructions for creating ESPHome configuration files, including optional substitutions for charging modes.
	- Included guidance on resolving potential compilation issues related to a missing header file.

- **Configuration**
	- Introduced a minimum version requirement of ESPHome 2024.2.0 in the configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->