### PR TITLE
feat: add Grid Energy sensor for HA Energy Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ By following these steps, you can easily find the Bluetooth MAC address of your 
 
 If you don't have the possibility to use the NRF Connect App, you can try scanning for bluetooth devices in your Chrome browser
 
-```
+```text
 chrome://bluetooth-internals/#devices
 ```
 

--- a/config/nexxtender_packages/charging_advanced_data.yaml
+++ b/config/nexxtender_packages/charging_advanced_data.yaml
@@ -57,6 +57,7 @@ sensor:
     unit_of_measurement: "kWh"
     state_class: total_increasing
     device_class: energy
+    icon: mdi:transmission-tower
   - platform: template
     name: "Car Power"
     id: ${charging_advanced_id_prefix}_car_power

--- a/config/nexxtender_packages/charging_advanced_data.yaml
+++ b/config/nexxtender_packages/charging_advanced_data.yaml
@@ -50,6 +50,13 @@ sensor:
     update_interval: ${charging_advanced_update_interval}
     lambda: |-
       return id(g_${charging_advanced_id_prefix}_grid_power);
+  - platform: integration
+    name: "${charging_advanced_prefix} Grid Energy"
+    sensor: ${charging_advanced_id_prefix}_grid_power
+    time_unit: h
+    unit_of_measurement: "kWh"
+    state_class: total_increasing
+    device_class: energy
   - platform: template
     name: "Car Power"
     id: ${charging_advanced_id_prefix}_car_power

--- a/config/nexxtender_packages/charging_grid_data.yaml
+++ b/config/nexxtender_packages/charging_grid_data.yaml
@@ -79,13 +79,6 @@ sensor:
     update_interval: ${charging_grid_update_interval}
     lambda: |-
       return id(g_${charging_grid_id_prefix}_consumed);
-  - platform: integration
-    name: "${charging_grid_prefix} Grid Energy"
-    sensor: ${charging_grid_id_prefix}_consumed
-    time_unit: h
-    unit_of_measurement: "kWh"
-    state_class: total_increasing
-    device_class: energy
   - platform: template
     name: "${charging_grid_prefix} Interval"
     id: ${charging_grid_id_prefix}_interval

--- a/config/nexxtender_packages/charging_grid_data.yaml
+++ b/config/nexxtender_packages/charging_grid_data.yaml
@@ -79,6 +79,13 @@ sensor:
     update_interval: ${charging_grid_update_interval}
     lambda: |-
       return id(g_${charging_grid_id_prefix}_consumed);
+  - platform: integration
+    name: "${charging_grid_prefix} Grid Energy"
+    sensor: ${charging_grid_id_prefix}_consumed
+    time_unit: h
+    unit_of_measurement: "kWh"
+    state_class: total_increasing
+    device_class: energy
   - platform: template
     name: "${charging_grid_prefix} Interval"
     id: ${charging_grid_id_prefix}_interval


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated README with an alternative method for finding Bluetooth MAC address using Chrome.
  - Enhanced installation and configuration instructions for ESPHome, including required version and ESP32 customization.

- **New Features**
  - Introduced a new grid energy consumption sensor in the charging configuration.
    - Tracks total energy consumed based on grid power.
    - Measures in kilowatt-hours (kWh).
    - Supports total increasing state tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->