### PR TITLE
fix: ESP32 S3 compatibility with IDF framework version 5

### DIFF
--- a/config/nexxtender_packages/esp.s3.yaml
+++ b/config/nexxtender_packages/esp.s3.yaml
@@ -20,7 +20,6 @@ light:
     rgb_order: GRB
     pin: GPIO48
     num_leds: 1
-    rmt_channel: 0
     chipset: ws2812
     name: ${friendly_name}
     effects:


### PR DESCRIPTION
Fixes #55 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated LED lighting configuration by removing the explicit channel assignment, now applying default channel behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->